### PR TITLE
Make the bottom of page source link more descriptive

### DIFF
--- a/theme/src/main/assets/source.st
+++ b/theme/src/main/assets/source.st
@@ -1,5 +1,6 @@
 $if(page.source_url)$
 <div class="source-github row">
-The source code for this page can be found <a href="$page.source_url$">here</a>.
+Found an error in this documentation? The source code for this page can be found <a href="$page.source_url$">here</a>.
+Please feel free to edit and contribute a pull request.
 </div>
 $endif$


### PR DESCRIPTION
Found and liked this wording on Lagom's documentation pages.