### PR TITLE
Adds cookie tool

### DIFF
--- a/theme/src/main/assets/analytics.st
+++ b/theme/src/main/assets/analytics.st
@@ -1,5 +1,5 @@
 <!--Google Analytics-->
-<script type="text/javascript">
+<script type="text/plain" class="optanon-category-2">
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '$page.properties.("google.analytics.account")$']);
   _gaq.push(['_setDomainName', '$page.properties.("google.analytics.domain.name")$']);
@@ -9,9 +9,7 @@
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })()
-</script>
-<!--Google Analytics & Marketo-->
-<script type="text/javascript">
+
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -20,12 +18,15 @@
   ga('tsTracker.require', 'linker');
   ga('tsTracker.linker:autoLink', ['lightbend.com','playframework.com','scala-lang.org','scaladays.org','spray.io','akka.io','scala-sbt.org','scala-ide.org']);
   ga('tsTracker.send', 'pageview');
+</script>
+<!--Marketo-->
+<script type="text/plain" class="optanon-category-3">
   (function() {
       var didInit = false;
       function initMunchkin() {
       if(didInit === false) {
         didInit = true;
-        Munchkin.init('558-NCX-702');
+        Munchkin.init('558-NCX-702', { 'asyncOnly': true, 'disableClickDelay': true });
       }
       }
       var s = document.createElement('script');

--- a/theme/src/main/assets/analytics.st
+++ b/theme/src/main/assets/analytics.st
@@ -9,7 +9,8 @@
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })()
-
+</script>
+<script type="text/plain" class="optanon-category-2">
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/theme/src/main/assets/css/page.css
+++ b/theme/src/main/assets/css/page.css
@@ -831,3 +831,110 @@ body.nav-open {
   padding-right: 1rem;
   padding-bottom: 1rem;
 }
+
+/*oneTrust cookie*/
+
+body .optanon-alert-box-wrapper .optanon-alert-box-bottom-top {
+    height: 20px
+}
+
+body .optanon-alert-box-wrapper .optanon-alert-box-bottom-padding {
+    padding-bottom: 20px
+}
+
+.lightbend-privacy-cookie-footer {
+    padding: 1rem 0 1rem 0;
+    color: white;
+    vertical-align: middle
+}
+
+.lightbend-privacy-cookie-footer p {
+    font-size: 0.875rem;
+    vertical-align: middle
+}
+
+.lightbend-privacy-cookie-footer .optanon-show-settings-wrapper {
+    display: inline-block;
+    vertical-align: middle
+}
+
+.optanon-cookie-policy-group {
+    padding-top: 4rem
+}
+
+.optanon-cookie-policy-group:first-child {
+    padding-top: 0
+}
+
+.optanon-cookie-policy-group-name {
+    font-weight: 700;
+    margin-bottom: 0.5rem
+}
+
+.optanon-cookie-policy-subgroup-table-column-header {
+    font-weight: 700
+}
+
+.cookie-warning {
+    background: #6cc04a;
+    display: inline-block;
+    margin: 1rem 0;
+    padding: 1rem;
+    font-weight: 700;
+    border-radius: 3px;
+    text-align: center
+}
+
+.cookie-warning p {
+    color: white !important;
+    font-size: 1rem !important;
+    margin: 0
+}
+
+.cookie-warning p>a {
+    border: 1px solid white;
+    color: white;
+    display: inline-block;
+    padding: .25rem .5rem;
+    text-decoration: none;
+    margin: .25rem 1rem;
+    cursor: pointer
+}
+
+.cookie-warning p>a:hover {
+    background: rgba(255, 255, 255, 0.6);
+    color: #6cc04a
+}
+
+.cookie-warning small {
+    color: white !important;
+    font-size: .875rem !important
+}
+
+.flex-video {
+    background-color: #ebeef0;
+    text-align: center
+}
+
+.flex-video .cookie-warning {
+    background: transparent;
+    padding: .5rem 2rem;
+    margin: 2rem auto 0 auto
+}
+
+.flex-video .cookie-warning p {
+    color: #15A9CE !important
+}
+
+.flex-video .cookie-warning p>a {
+    display: block;
+    margin: 1rem auto;
+    max-width: 300px;
+    border: 1px solid #15A9CE;
+    color: #15A9CE
+}
+
+.flex-video .cookie-warning p>a:hover {
+    background: #107F9B;
+    color: white
+}

--- a/theme/src/main/assets/page.st
+++ b/theme/src/main/assets/page.st
@@ -25,6 +25,12 @@ $endif$
 <meta name="msapplication-TileColor" content="#15a9ce">
 <meta name="theme-color" content="#15a9ce">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<!-- OneTrust Cookies Consent Notice (Production Standard, akka.io, en-GB) start -->
+<script src="https://optanon.blob.core.windows.net/consent/159bb13d-6748-4399-806e-ac28db879785.js" type="text/javascript" charset="UTF-8"></script>
+<script type="text/javascript">
+function OptanonWrapper() { }
+</script>
+<!-- OneTrust Cookies Consent Notice (Production Standard, akka.io, en-GB) end -->
 $analytics()$
 </head>
 
@@ -116,8 +122,15 @@ $source()$
 <footer class="page-footer row clearfix">
 <img class="akka-icon float-left show-for-medium" src="$page.base$images/akka-icon.svg">
 <section class="copyright">
-<div>&copy; 2011-$page.properties.("date.year")$ <a href="https://www.lightbend.com">Lightbend</a></div>
 <div>$page.properties.("project.name")$ is Open Source and available under the Apache 2 License.</div>
+<p class="legal">
+    &copy; 2011-$page.properties.("date.year")$ <a href="https://www.lightbend.com" target="_blank">Lightbend, Inc.</a> | 
+    <a href="https://www.lightbend.com/legal/licenses" target="_blank">Licenses</a> | 
+    <a href="https://www.lightbend.com/legal/terms" target="_blank">Terms</a> | 
+    <a href="https://www.lightbend.com/legal/privacy" target="_blank">Privacy Policy</a> | 
+    <a href="https://akka.io/cookie/" target="_blank">Cookie Listing</a> | 
+    <a class="optanon-toggle-display">Cookie Settings</a>
+  </p>
 </section>
 </footer>
 


### PR DESCRIPTION
Adds cookie banner, preference center and legal footer to theme.

**Please test locally first**, as I could not get my local dev environment to work.

To test locally swap out line 29 in page.st with the following include
`<script src="https://optanon.blob.core.windows.net/consent/159bb13d-6748-4399-806e-ac28db879785-test.js" type="text/javascript" charset="UTF-8"></script>`