### PR TITLE
Remove weird color shade for body text

### DIFF
--- a/theme/src/main/assets/css/page-2.css
+++ b/theme/src/main/assets/css/page-2.css
@@ -45,7 +45,6 @@ body {
   cursor: default;
   font-family: "ProximaNova", Arial, Helvetica, sans-serif;
   font-size: 1em;
-  color: #0c323b;
   font-smoothing: antialiased;
   -webkit-font-smoothing: antialiased;
   -moz-font-smoothing: antialiased;


### PR DESCRIPTION
I always quint my eyes when looking at the akka docs because of this slight difference in font color between bullet items and the rest of the text. It seems this double color definition is the reason. There's another `color: #000` a few lines above.