### PR TITLE
Copyright section in separate template

### DIFF
--- a/theme/src/main/assets/copyright.st
+++ b/theme/src/main/assets/copyright.st
@@ -1,0 +1,13 @@
+					<section class="copyright">
+$if(page.property_is.("project.license").("Apache-2.0"))$
+						<div>$page.properties.("project.name")$ is Open Source and available under the Apache 2 License.</div>
+$endif$
+						<p class="legal">
+							&copy; 2011-$page.properties.("date.year")$ <a href="https://www.lightbend.com" target="_blank">Lightbend, Inc.</a> |
+							<a href="https://www.lightbend.com/legal/licenses" target="_blank">Licenses</a> |
+							<a href="https://www.lightbend.com/legal/terms" target="_blank">Terms</a> |
+							<a href="https://www.lightbend.com/legal/privacy" target="_blank">Privacy Policy</a> |
+							<a href="https://akka.io/cookie/" target="_blank">Cookie Listing</a> |
+							<a class="optanon-toggle-display">Cookie Settings</a>
+						</p>
+					</section>

--- a/theme/src/main/assets/page.st
+++ b/theme/src/main/assets/page.st
@@ -117,19 +117,7 @@ $analytics()$
 				$source()$
 				<footer class="page-footer row clearfix">
 					<img class="akka-icon float-left show-for-medium" src="$page.base$images/akka-icon.svg" />
-					<section class="copyright">
-$if(page.property_is.("project.license").("Apache-2.0"))$
-						<div>$page.properties.("project.name")$ is Open Source and available under the Apache 2 License.</div>
-$endif$
-						<p class="legal">
-							&copy; 2011-$page.properties.("date.year")$ <a href="https://www.lightbend.com" target="_blank">Lightbend, Inc.</a> |
-							<a href="https://www.lightbend.com/legal/licenses" target="_blank">Licenses</a> |
-							<a href="https://www.lightbend.com/legal/terms" target="_blank">Terms</a> |
-							<a href="https://www.lightbend.com/legal/privacy" target="_blank">Privacy Policy</a> |
-							<a href="https://akka.io/cookie/" target="_blank">Cookie Listing</a> |
-							<a class="optanon-toggle-display">Cookie Settings</a>
-						</p>
-					</section>
+					$copyright()$
 				</footer>
 			</section>
 		</main>


### PR DESCRIPTION
Move the copyright section to a separate template part so that it can be overridden eg for Alpakka Samples which should apply the CC0 license.
