### PR TITLE
Bundle apidoc and project-info; style for API links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ before_cache:
 
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
+    - $HOME/.sbt
     - $HOME/.jabba/jdk
 
 deploy:
@@ -29,7 +30,7 @@ deploy:
 
 env:
   global:
-    - TRAVIS_JDK=adopt@~1.8.202-08
+    - TRAVIS_JDK=adopt@~1.8.0-222
     # encrypt with: travis encrypt BINTRAY_USER=...
     - secure: "TZ5/EpN2ZlMaEoY3A/tSkhia6pJm8dAOs5Be2uE7GVl9O/frE8fgp96G8kI6PicexM5Awwpkf94o50FVWx+89GyXVDHMPlOUIdiPANPo7YlNjgovzVAF5i6HK5nqpJWetdp+i/JanMDCJ9Cu9A+vE6KTUat1ye0qKLW2s8TOWMpL9Zz/fq1eQmZNvXOzBwMVYfDLXILYYOw5AdeS8o2OYw+rpymTU5oHwT0xOAdTAYSUqKJGPeWzg7wI/npZmCJ7h/JS3rZxdEWmWSRg+6zIOOtHm5ggPB4/TkoT9me/OobYex53tmeowRBFGVojfPK0UGvqJtMuMkv+GMu9oqBiVrf+XNMwDc8Awe0ewv9CRfTY4GnqLicePFS83Xo9KT1PqxzeEAO+kbL40gIZgoySvlwrgfGBvXRm4ucAjDB2ZBa6wGEJwWDYISH7yXJ2NVSlGQ1DpepwwuDfrKCuwbZLbK1wpS/KkOW4vFlHkYbiPmwmTtnxpb0zhzzCCemb9yDn395IDHCRzGolY3Q9ic6JQlxKXPBDkzwG/Qb27y5XdQ0WKow+9EvWGzbHFnsAzR7XtKL2oOUWLpD4G1D7/nP/zwAXifrN2O5aoM0wjXWDBAtaOXhd2D3xy9uS3zC0r2v9Ht43L+Syb962Dc0MvGHe0rfXi08TafsQEi+xiK2xC8o="
     # encrypt with: travis encrypt BINTRAY_PASS=...

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,10 @@ lazy val akkaPlugin = project
     scriptedBufferLog := false,
     bintrayRepository := "sbt-plugin-releases",
     addSbtPlugin(
-      "com.lightbend.paradox" % "sbt-paradox" % "0.6.5"
+      "com.lightbend.paradox" % "sbt-paradox" % "0.6.6"
     ),
+    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.4"),
+    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.3"),
     resourceGenerators in Compile += Def.task {
       val file = (resourceManaged in Compile).value / "akka-paradox.properties"
       IO.write(file, s"akka.paradox.version=${version.value}")

--- a/theme/src/main/assets/css/page-5.css
+++ b/theme/src/main/assets/css/page-5.css
@@ -341,11 +341,17 @@ pre > code {
   padding: 0 !important;
 }
 
-h1 code, h2 code, h3 code, h4 code, h5 code, h6 code, a code {
+h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
   border: none;
   background: inherit;
   color: inherit;
   padding: 0 !important;
+}
+
+a code {
+  border: none;
+  color: inherit;
+  font-weight: bold !important;
 }
 
 /* definition lists */

--- a/theme/src/main/assets/page.st
+++ b/theme/src/main/assets/page.st
@@ -18,7 +18,7 @@ $endif$
 <link rel="stylesheet" type="text/css" href="$page.base$lib/foundation/dist/css/foundation.min.css"/>
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
 <link rel="stylesheet" type="text/css" href="$page.base$css/icons.css"/>
-<link rel="stylesheet" type="text/css" href="$page.base$css/page-4.css"/>
+<link rel="stylesheet" type="text/css" href="$page.base$css/page-5.css"/>
 <link rel="stylesheet" type="text/css" href="$page.base$css/banner.css"/>
 <link rel="shortcut icon" href="$page.base$images/favicon.ico" />
 <link rel="apple-touch-icon" sizes="180x180" href="$page.base$images/apple-touch-icon.png"/>


### PR DESCRIPTION
## Purpose

* Add sbt-paradox-apidoc and sbt-paradoc-project-info as transitive dependencies
* Update style for `a code` for better readablity

## Background Context

Paradox 0.6.6 wraps links to API (`@scaladoc`/`@javadoc`/`@apidoc`) in `<code>` now, this aligns the styling of those with the style of code in backticks.
