### PR TITLE
fix: move sonatypeProfileName to Publish.scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 scalaVersion := "2.13.5"
 
-sonatypeProfileName := "com.lightbend"
 licenses += "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")
 
 lazy val akkaParadox = project

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,12 +1,12 @@
 import sbt._
 import sbt.Keys._
-import sbt.plugins.JvmPlugin
 
 object Publish extends AutoPlugin {
 
   override def trigger = allRequirements
 
   override def projectSettings = Seq(
+    organization := "com.lightbend",
     homepage := Some(url("https://developer.lightbend.com/docs/paradox")),
     developers := List(
       Developer(


### PR DESCRIPTION
Some clean-up, as clarified in https://github.com/akka/akka-paradox/pull/149#discussion_r675214400
