### PR TITLE
Set sonatypeProfileName in Publish auto-plugin

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,12 +1,15 @@
 import sbt._
 import sbt.Keys._
+import xerial.sbt.Sonatype
 
 object Publish extends AutoPlugin {
+  import Sonatype.autoImport.sonatypeProfileName
 
   override def trigger = allRequirements
+  override def requires = Sonatype
 
   override def projectSettings = Seq(
-    organization := "com.lightbend",
+    sonatypeProfileName := "com.lightbend",
     homepage := Some(url("https://developer.lightbend.com/docs/paradox")),
     developers := List(
       Developer(


### PR DESCRIPTION
Another follow-up to `sonatypeProfileName` after #152.

Set the same on all projects:

```
sbt akkaParadox ❯ sonatypeProfileName
[info] akkaTheme / sonatypeProfileName
[info] 	com.lightbend
[info] akkaPlugin / sonatypeProfileName
[info] 	com.lightbend
[info] sonatypeProfileName
[info] 	com.lightbend
```

While organization is back to:

```
sbt akkaParadox ❯ organization
[info] akkaTheme / organization
[info] 	com.lightbend.akka
[info] akkaPlugin / organization
[info] 	com.lightbend.akka
[info] organization
[info] 	akkaparadox
```