### PR TITLE
Revert "Update foundation to 6.4.3-1 (#120)"

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin  = [
+  { groupId = "org.webjars", artifactId = "foundation", version = "6.3." }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,11 @@ lazy val akkaTheme = project
     organization := "com.lightbend.akka",
     name := "paradox-theme-akka",
     libraryDependencies ++= Seq(
-      "org.webjars" % "foundation" % "6.4.3-1" % "provided",
+      // There are newer versions of foundation available, but
+      // they break the 3-column indexes and the left margin on
+      // zoomed-in breakpoints, so let's stick with 6.3.1 until
+      // we find time to fix that.
+      "org.webjars" % "foundation" % "6.3.1" % "provided",
       "org.webjars" % "prettify" % "4-Mar-2013-1" % "provided"
     )
   )


### PR DESCRIPTION
This reverts commit abe2ba3adee55038f5c28b65c181f2bc14b3f77e
and configures scala-steward to stick with 6.3 for now,
because it broke the 3-column index and (when zoomed-in)
the left margin