### PR TITLE
Use sbt-paradox-lightbend-project-info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val akkaPlugin = project
       "com.lightbend.paradox" % "sbt-paradox" % "0.9.2"
     ),
     addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.10.1"),
-    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.10"),
+    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-lightbend-project-info" % "1.0.0"),
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "akka-paradox.properties"
       IO.write(file, s"akka.paradox.version=${version.value}")


### PR DESCRIPTION
This PR uses sbt-paradox-lightbend-project-info instead of sbt-paradox-project-info, see https://github.com/lightbend/sbt-paradox-project-info/pull/34 for context
