### PR TITLE
ci: renovate GH workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,23 +3,26 @@ name: Build and test
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8.0
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.8.0
 
       - name: sbt test
         run: sbt test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,21 +5,28 @@ on:
     branches: [ main ]
     tags: [ v* ]
 
+permissions:
+  contents: read
+
 jobs:
   sbt:
     name: sbt publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    if: github.repository == 'akka/akka-paradox'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
       - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
+        uses: coursier/setup-action@v1.3.0
         with:
-          java-version: adopt@1.8
+          jvm: temurin:1.8.0
 
       - name: Publish
         run: |-

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+    - main
+    - release-*
+
+permissions:
+  contents: read # allow actions/checkout
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-22.04
+    if: github.repository == 'akka/akka-paradox'
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged
+      # https://github.com/release-drafter/release-drafter/releases
+      # v5.21.1
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,6 @@
+pullRequests.frequency = "@monthly"
+commits.message = "bump: ${artifactName} ${nextVersion} (was ${currentVersion})"
+
 updates.pin  = [
   { groupId = "org.webjars", artifactId = "foundation", version = "6.3." }
 ]


### PR DESCRIPTION
Current versions of actions.
Switch to coursier for JDK management.