### PR TITLE
fix: Hide build tool selector from navbar

### DIFF
--- a/theme/src/main/assets/css/page-8.css
+++ b/theme/src/main/assets/css/page-8.css
@@ -1090,3 +1090,8 @@ table.project-info td {
 a.project-info-toggle {
   margin-bottom: 16px;
 }
+
+/* hide build tool selector in navbar */
+select[name="BuildTool"] {
+  display: none;
+}


### PR DESCRIPTION
Breaks the layout

Manually applied to published Akka 2.9.1 (but waiting for CDN to pick it up)